### PR TITLE
fix problem setting up --session-cookies parameter for command line

### DIFF
--- a/lib/httperf.rb
+++ b/lib/httperf.rb
@@ -150,6 +150,8 @@ class HTTPerf
     opts.gsub!("--hog=false", "")
     opts.gsub!("--verbose=true", "--verbose")
     opts.gsub!("--verbose=false", "")
+    opts.gsub!("--session-cookies=true", "--session-cookies")
+    opts.gsub!("--session-cookies=false", "")
     opts
   end
 

--- a/spec/httperf_spec.rb
+++ b/spec/httperf_spec.rb
@@ -74,6 +74,7 @@ describe HTTPerf, "basic usage" do
         "--num-conns 2 --server foobar",
         "--server=foobar --rate 10",
         "--server fooar --rate=10",
+        "--session-cookies=true --wsess='10,1,1'",
         "--num-conns=2 --hog --verbose",
         "--num-conns 2" ].each do |param|
         expect { HTTPerf.new("command" => "httperf #{param}") }.to_not raise_error


### PR DESCRIPTION
The --session-cookies parameter to httperf has no arguments so we need to prepare our option just like we do with --hog and --verbose.
